### PR TITLE
refactor: simplify contract-initiated-roundtrip-execution to single e…

### DIFF
--- a/core-sdk-functions/contract-initiated-roundtrip-execution/README.md
+++ b/core-sdk-functions/contract-initiated-roundtrip-execution/README.md
@@ -6,7 +6,7 @@ A Push Chain contract dispatches an outbound transaction to BNB Testnet AND is w
 
 ## Status (Donut testnet, May 2026) — ✅ working end-to-end
 
-Verified complete round-trip at dispatcher `0x94D2FA05f854588bb2E1dC40d97f338618cBDc6c`: `outboundCount` 0→1 (Push leg + UGPC outbound emit), BNB CEA `0x32025e2B…Cb26` deployed by TSS validators, BNB-side multicall executed (CEA self-call to `sendUniversalTxToUEA`), and the inbound back-leg landed on Push via `executeUniversalTx(string,bytes,bytes,uint256,address,bytes32)` — `inboundCount` 0→1, `lastInboundTxId = 0xcf3d0150…48dd`.
+Verified complete round-trip at dispatcher `0x94D2FA05f854588bb2E1dC40d97f338618cBDc6c`: `outboundCount` 0→1 (Push leg + UGPC outbound emit), BNB CEA `0x32025e2B…Cb26` deployed by TSS validators, BNB-side multicall executed (CEA self-call to `sendUniversalTxToUEA`), and the inbound back-leg landed on Push via the docs-style 6-arg `executeUniversalTx(string,bytes,bytes,uint256,address,bytes32)` — `callbacks` 0→1, `lastTxId = 0xcf3d0150…48dd`.
 
 **Three configurations needed to make the back-leg fire**, all verified by elimination across earlier failed runs:
 
@@ -14,14 +14,14 @@ Verified complete round-trip at dispatcher `0x94D2FA05f854588bb2E1dC40d97f338618
 2. **Contract pre-funded with PC.** Per [the docs](https://push.org/docs/chain/build/contract-initiated-multichain-execution): "the CEA inbound to Push Chain needs $PC for execution fees. Funding your Push-side contract with $PC is your responsibility." 1.5 PC was sufficient with the wire format below.
 3. **Outbound payload uses the SDK Route 3 wire format**: the destination CEA's outer multicall must include a step that **self-calls** `CEA.sendUniversalTxToUEA(token, amount, encodedUniversalPayload, revertRecipient)`. That self-call is what the TSS uses as the trigger to fire the inbound. Plain multicalls (no self-call to `sendUniversalTxToUEA`) DID NOT trigger the back-leg, even with sufficient gas/PC.
 
-**Empirical answer for which `executeUniversalTx` overload TSS calls on a Push-native contract:** the **docs-style 6-arg version** `executeUniversalTx(string sourceChainNamespace, bytes ceaAddress, bytes payload, uint256 amount, address prc20, bytes32 txId)`. The UEA-style 2-arg version (`executeUniversalTx(UniversalPayload, bytes)`) is reserved for actual UEA proxy accounts and does NOT fire here — confirmed by deploying a contract with both overloads side-by-side and observing only the 6-arg counter advance.
+> The `executeUniversalTx` signature TSS dispatches to for Push-native contracts is the **docs-style 6-arg version** `(string sourceChainNamespace, bytes ceaAddress, bytes payload, uint256 amount, address prc20, bytes32 txId)`. The 2-arg `executeUniversalTx(UniversalPayload, bytes)` overload in the codebase is for actual UEA proxy accounts and is not invoked for ordinary Push contracts; this example implements only the 6-arg path.
 
 ## What this example contains
 
 | File | Purpose |
 |---|---|
-| [`src/RoundtripDispatcher.sol`](src/RoundtripDispatcher.sol) | The single Push Chain contract. `kickOff(...)` dispatches outbound; `executeUniversalTx(...)` is the gated back-leg handler the executor module would invoke. Holds its own PC via `fund()`. |
-| [`index.ts`](index.ts) | Auto-deploys the contract, funds it with PC if empty, derives the BNB CEA, calls `kickOff`, and polls both the BNB counter (forward leg) and the dispatcher's `inboundCount` (back-leg). |
+| [`src/RoundtripDispatcher.sol`](src/RoundtripDispatcher.sol) | The single Push Chain contract. `kickOff(...)` dispatches outbound; `executeUniversalTx(...)` is the gated back-leg handler the executor module invokes. Holds its own PC via `fund()`. |
+| [`index.ts`](index.ts) | Auto-deploys the contract, funds it with PC if empty, derives the BNB CEA, calls `kickOff`, and polls both the BNB CEA bytecode (forward leg) and the dispatcher's `callbacks` (back-leg). |
 | [`foundry.toml`](foundry.toml) | Foundry config — pinned to Shanghai. |
 
 ## Flow (as designed)
@@ -38,18 +38,17 @@ RoundtripDispatcher.kickOff
          ▼
        UGPC ───emit event──▶  TSS validators ──submit──▶  BNB CEA
        0x...C1                                            │ (deployed lazily)
-                                                          │ (3) increment() on BNB counter
+                                                          │ (3) CEA self-calls sendUniversalTxToUEA
                                                           ▼
-                                                       BNB Counter
-                                                  msg.sender == CEA
+                                                  gateway.sendUniversalTxFromCEA
 
 Once the destination tx finalizes, TSS automatically:
                           ┌────────────────────────────────────────┐
                           │                                        │
                           ▼                                        │
        UNIVERSAL_EXECUTOR_MODULE ──executeUniversalTx──▶ RoundtripDispatcher.executeUniversalTx
-       0x14191Ea5...Df7d7                                          │ inboundCount += 1
-                                                                   │ executedTxIds[txId] = true
+       0x14191Ea5...Df7d7                                          │ callbacks += 1
+                                                                   │ seenTxIds[txId] = true
                                                                    ▼
                                                              (callback complete)
 ```
@@ -80,7 +79,7 @@ cp .env.sample .env
 npm start
 ```
 
-Expected output (forward leg works; back-leg is the part currently TSS-blocked):
+Expected output:
 
 ```
 🔑 Push EOA: 0x...
@@ -90,33 +89,31 @@ Expected output (forward leg works; back-leg is the part currently TSS-blocked):
    ✅ deployed at: 0x...
 
 📊 Dispatcher balance: 0 PC
-💸 Funding contract with 8.0 PC (one-time)...
+💸 Funding contract with 8.0 PC...
    ✅ Dispatcher balance now: 8.0 PC
 
 📍 Dispatcher's CEA on BNB: 0x...
 
 📊 Pre-kick state:
    outboundCount: 0
-   inboundCount:  0
-   BNB counter:   <N>
+   callbacks:     0
 
 🚀 Calling kickOff() on Push contract...
    📤 Push kickOff tx: 0x...
    ✅ Push leg settled.
 
-📡 Waiting for the round-trip to complete...
+📡 Watching for the inbound callback...
 
-✅ Forward leg landed:
-   BNB counter: <N> → <N+1>
+✅ BNB CEA deployed by TSS (forward leg landed)
 
-⚠️  Did not observe `inboundCount` advance within 6 minutes.
-   The forward leg landed (BNB counter advanced), but the TSS
-   auto-callback to executeUniversalTx has not arrived yet.
+🎉 Inbound callback fired!
+   callbacks: 0 → 1
+   lastTxId:  0x...
 ```
 
 ## Wire format details
 
-The outbound payload is the same simple format as the one-way outbound example: `0x2cc2842d` (UEA_MULTICALL marker) + `abi.encode((address,uint256,bytes)[])` with a single call to `BNB counter.increment()`. No nested gateway calls, no special opt-in flag — just the documented format.
+The outbound payload uses the **SDK Route 3 wire format**: a single-step outer multicall whose only call is the destination CEA self-calling `sendUniversalTxToUEA(token=0, amount=0, innerUniversalPayload, revertRecipient=this)`. The inner UniversalPayload carries the multicall the UEA on Push should execute when the inbound lands.
 
 The inbound handler matches the docs:
 
@@ -130,23 +127,24 @@ function executeUniversalTx(
     bytes32 txId
 ) external payable {
     if (msg.sender != universalExecutorModule) revert NotUniversalExecutor();
-    if (executedTxIds[txId]) revert TxAlreadyExecuted();
-    executedTxIds[txId] = true;
-    inboundCount += 1;
-    // ... record txId, sourceChain, etc.
+    if (seenTxIds[txId]) revert TxAlreadyExecuted();
+    seenTxIds[txId] = true;
+    callbacks += 1;
+    lastTxId = txId;
+    emit Callback(callbacks, txId, sourceChainNamespace, ceaAddress, prc20, amount);
 }
 ```
 
 ## Key contract surface
 
 ```solidity
-constructor(address _ugpc, address _module, address _destinationContract);
+constructor(address _ugpc, address _module);
 function fund() external payable;
 function kickOff(
-    bytes calldata destinationCEABytes,
+    address destinationCEAAddr,
     address tokenForRouting,
-    bytes calldata destinationCalldata,
-    uint256 protocolFeePc
+    uint256 protocolFeePc,
+    uint256 ueaNonce
 ) external;
 function executeUniversalTx(
     string calldata sourceChainNamespace,
@@ -157,9 +155,8 @@ function executeUniversalTx(
     bytes32 txId
 ) external payable;
 function outboundCount() view returns (uint256);
-function inboundCount() view returns (uint256);
-function lastInboundTxId() view returns (bytes32);
-function lastInboundSourceChain() view returns (string);
+function callbacks() view returns (uint256);
+function lastTxId() view returns (bytes32);
 ```
 
 ## Network
@@ -168,7 +165,6 @@ function lastInboundSourceChain() view returns (string);
   - UGPC: `0x00000000000000000000000000000000000000C1`
   - Universal Executor Module: `0x14191Ea54B4c176fCf86f51b0FAc7CB1E71Df7d7`
 - BNB Testnet (chain id `97`)
-  - Counter target: `0x7f0936bb90e7dcf3edb47199c2005e7184e44cf8`
 - Routing token: `0x7a9082dA308f3fa005beA7dB0d203b3b86664E36` (pBNB)
 
 ## Related examples

--- a/core-sdk-functions/contract-initiated-roundtrip-execution/index.ts
+++ b/core-sdk-functions/contract-initiated-roundtrip-execution/index.ts
@@ -1,17 +1,16 @@
 // Full Documentation: https://push.org/docs/chain/build/contract-initiated-multichain-execution
 //
-// Round-Trip Multichain Execution — Dual Inbound Probe
-// ====================================================
+// Round-Trip Multichain Execution
+// ===============================
 // Push contract → UGPC → BNB CEA → CEA self-calls sendUniversalTxToUEA →
-// gateway.sendUniversalTxFromCEA → TSS dispatches inbound to Push contract
-// (= the CEA's pushAccount).
+// gateway.sendUniversalTxFromCEA → TSS dispatches inbound back to the Push
+// contract (= the CEA's pushAccount) via the 6-arg `executeUniversalTx`.
 //
-// The contract implements BOTH `executeUniversalTx` overloads so we can
-// see empirically which one TSS dispatches to:
-//   - UEA-style: `executeUniversalTx(UniversalPayload, bytes)`
-//   - Docs-style: `executeUniversalTx(string, bytes, bytes, uint256, address, bytes32)`
-// On Donut Testnet, only the docs-style 6-arg version fires for Push-native
-// contracts (`docsStyleCallbacks` advances; `ueaStyleCallbacks` stays at 0).
+// The contract implements the docs-style 6-arg `executeUniversalTx` because
+// that is the signature TSS dispatches to for Push-native contracts. The
+// 2-arg `executeUniversalTx(UniversalPayload, bytes)` overload in the
+// codebase is for actual UEA proxy accounts and is not invoked for ordinary
+// Push contracts.
 
 import 'dotenv/config';
 import { PushChain } from '@pushchain/core';
@@ -30,13 +29,10 @@ const DISPATCHER_ABI = [
   'function fund() external payable',
   'function kickOff(address destinationCEAAddr, address tokenForRouting, uint256 protocolFeePc, uint256 ueaNonce) external',
   'function outboundCount() view returns (uint256)',
-  'function ueaStyleCallbacks() view returns (uint256)',
-  'function docsStyleCallbacks() view returns (uint256)',
-  'function lastUeaPayloadNonce() view returns (uint256)',
-  'function lastDocsTxId() view returns (bytes32)',
+  'function callbacks() view returns (uint256)',
+  'function lastTxId() view returns (bytes32)',
   'event OutboundKicked(uint256 outboundCount, bytes payload)',
-  'event UeaStyleCallback(uint256 sequence, uint256 payloadNonce, uint8 vType, bytes payloadData)',
-  'event DocsStyleCallback(uint256 sequence, bytes32 indexed txId, string sourceChainNamespace, bytes ceaAddress, address prc20, uint256 amount)',
+  'event Callback(uint256 sequence, bytes32 indexed txId, string sourceChainNamespace, bytes ceaAddress, address prc20, uint256 amount)',
 ];
 
 async function main() {
@@ -47,7 +43,7 @@ async function main() {
   }
 
   console.log('═══════════════════════════════════════════════════════════════');
-  console.log('  Contract-Initiated Round-Trip — Dual Inbound Probe');
+  console.log('  Contract-Initiated Round-Trip Multichain Execution');
   console.log('═══════════════════════════════════════════════════════════════\n');
 
   const pushProvider = new ethers.JsonRpcProvider(RPC_PUSH);
@@ -107,12 +103,10 @@ async function main() {
 
   // 4) Snapshot starting state.
   const startOutbound: bigint = await dispatcher.outboundCount();
-  const startUea: bigint = await dispatcher.ueaStyleCallbacks();
-  const startDocs: bigint = await dispatcher.docsStyleCallbacks();
+  const startCallbacks: bigint = await dispatcher.callbacks();
   console.log(`📊 Pre-kick state:`);
-  console.log(`   outboundCount:       ${startOutbound}`);
-  console.log(`   ueaStyleCallbacks:   ${startUea}`);
-  console.log(`   docsStyleCallbacks:  ${startDocs}`);
+  console.log(`   outboundCount: ${startOutbound}`);
+  console.log(`   callbacks:     ${startCallbacks}`);
 
   // 5) Kick off — pass ueaNonce=0 (Push-native contract has no UEA proxy nonce).
   console.log('\n🚀 Calling kickOff() on Push contract...');
@@ -132,47 +126,35 @@ async function main() {
   const recK = await txKick.wait();
   console.log(`   ✅ Push leg settled. status=${recK?.status === 1 ? 'success' : 'failed'} block=${recK?.blockNumber}`);
 
-  // 6) Poll for the back-leg via either path.
-  console.log('\n📡 Watching for both inbound paths to fire (typically 1-3 min total)...');
-  console.log('   Whichever counter advances tells us which signature TSS uses.\n');
+  // 6) Poll for the back-leg.
+  console.log('\n📡 Watching for the inbound callback (typically 1-3 min total)...\n');
 
   const deadline = Date.now() + 8 * 60 * 1000;
   let bnbDeployed = false;
   while (Date.now() < deadline) {
-    const [code, ueaC, docsC] = await Promise.all([
+    const [code, callbacksNow] = await Promise.all([
       bnbProvider.getCode(bnbCEA.address),
-      dispatcher.ueaStyleCallbacks() as Promise<bigint>,
-      dispatcher.docsStyleCallbacks() as Promise<bigint>,
+      dispatcher.callbacks() as Promise<bigint>,
     ]);
     const isDeployed = code !== '0x';
     if (isDeployed && !bnbDeployed) {
       bnbDeployed = true;
       console.log(`✅ BNB CEA deployed by TSS (forward leg landed)`);
     }
-    if (ueaC > startUea) {
-      const lastNonce = await dispatcher.lastUeaPayloadNonce();
-      console.log(`\n🎉 UEA-STYLE inbound fired!`);
-      console.log(`   ueaStyleCallbacks: ${startUea} → ${ueaC}`);
-      console.log(`   lastUeaPayloadNonce: ${lastNonce}`);
-      console.log(`   ▶ TSS dispatches via executeUniversalTx(UniversalPayload, bytes)`);
-      return;
-    }
-    if (docsC > startDocs) {
-      const lastTx = await dispatcher.lastDocsTxId();
-      console.log(`\n🎉 DOCS-STYLE inbound fired!`);
-      console.log(`   docsStyleCallbacks: ${startDocs} → ${docsC}`);
-      console.log(`   lastDocsTxId: ${lastTx}`);
-      console.log(`   ▶ TSS dispatches via executeUniversalTx(string,bytes,bytes,uint256,address,bytes32)`);
+    if (callbacksNow > startCallbacks) {
+      const lastTx = await dispatcher.lastTxId();
+      console.log(`\n🎉 Inbound callback fired!`);
+      console.log(`   callbacks: ${startCallbacks} → ${callbacksNow}`);
+      console.log(`   lastTxId:  ${lastTx}`);
       return;
     }
     await new Promise((r) => setTimeout(r, 8000));
   }
 
-  console.log('\n⚠️  Did not observe either inbound path within 8 minutes.');
+  console.log('\n⚠️  Did not observe the inbound callback within 8 minutes.');
   console.log(`   Forward leg deployed CEA: ${bnbDeployed ? 'yes' : 'no'}`);
-  console.log(`   ueaStyleCallbacks:   ${await dispatcher.ueaStyleCallbacks()}`);
-  console.log(`   docsStyleCallbacks:  ${await dispatcher.docsStyleCallbacks()}`);
-  console.log(`   Watch ${dispatcherAddress} on https://donut.push.network/ for either event.`);
+  console.log(`   callbacks: ${await dispatcher.callbacks()}`);
+  console.log(`   Watch ${dispatcherAddress} on https://donut.push.network/ for the Callback event.`);
 }
 
 async function getOrDeployFoundry(args: {

--- a/core-sdk-functions/contract-initiated-roundtrip-execution/src/RoundtripDispatcher.sol
+++ b/core-sdk-functions/contract-initiated-roundtrip-execution/src/RoundtripDispatcher.sol
@@ -9,17 +9,6 @@ pragma solidity ^0.8.26;
 // A Push Chain contract that dispatches an outbound to BNB Testnet AND
 // receives an automatic completion callback when the back-leg lands.
 //
-// **Why two `executeUniversalTx` overloads?** Push Chain's codebase exposes
-// two distinct inbound signatures:
-//   - `executeUniversalTx(UniversalPayload, bytes)`            — the UEA proxy interface
-//   - `executeUniversalTx(string, bytes, bytes, uint256, address, bytes32)` — the docs example
-//
-// We implement both side-by-side so it's empirically obvious which one the
-// TSS Cosmos universal-executor module dispatches to for a Push-native
-// contract. **Verified on Donut Testnet (May 2026): only the docs-style
-// 6-arg version fires.** Counter `docsStyleCallbacks` advanced; UEA-style
-// stayed at 0. The 2-arg path is reserved for actual UEA proxy accounts.
-//
 // **What makes the back-leg fire** (verified by elimination across earlier
 // failed runs):
 //   1. `gasLimit ≥ 2_000_000` on the UGPC outbound. The 500k auto-floor is
@@ -44,6 +33,12 @@ pragma solidity ^0.8.26;
 //                                                          ▼
 //                          TSS Cosmos universal-executor ──▶ this contract
 //                          (msg.sender == UNIVERSAL_EXECUTOR_MODULE)
+//
+// For Push-native contracts, TSS dispatches the docs-style 6-arg
+// `executeUniversalTx(string, bytes, bytes, uint256, address, bytes32)`.
+// The 2-arg `executeUniversalTx(UniversalPayload, bytes)` overload exists
+// in the codebase for actual UEA proxy accounts and is not invoked for
+// ordinary Push contracts; this contract implements only the 6-arg path.
 
 /// @notice UGPC outbound request — `target` is the destination CEA bytes.
 struct UniversalOutboundTxRequest {
@@ -74,20 +69,10 @@ contract RoundtripDispatcher {
     // -------------------------------------------------------------------------
 
     uint256 public outboundCount;
+    uint256 public callbacks;
 
-    /// @notice Bumped each time TSS delivers via UEA-style entry
-    /// (`executeUniversalTx(UniversalPayload, bytes)`).
-    /// Empirically stays at 0 for Push-native contracts.
-    uint256 public ueaStyleCallbacks;
-
-    /// @notice Bumped each time TSS delivers via docs-style entry
-    /// (`executeUniversalTx(string, bytes, bytes, uint256, address, bytes32)`).
-    /// Empirically the path that fires for Push-native contracts.
-    uint256 public docsStyleCallbacks;
-
-    mapping(bytes32 => bool) public seenDocsTxIds;
-    bytes32 public lastDocsTxId;
-    uint256 public lastUeaPayloadNonce;
+    mapping(bytes32 => bool) public seenTxIds;
+    bytes32 public lastTxId;
 
     // -------------------------------------------------------------------------
     // Events / Errors
@@ -96,8 +81,7 @@ contract RoundtripDispatcher {
     event Funded(address indexed from, uint256 amount, uint256 newBalance);
     event OutboundKicked(uint256 outboundCount, bytes payload);
 
-    event UeaStyleCallback(uint256 sequence, uint256 payloadNonce, uint8 vType, bytes payloadData);
-    event DocsStyleCallback(
+    event Callback(
         uint256 sequence,
         bytes32 indexed txId,
         string sourceChainNamespace,
@@ -114,18 +98,6 @@ contract RoundtripDispatcher {
     // -------------------------------------------------------------------------
     // Types
     // -------------------------------------------------------------------------
-
-    struct UniversalPayload {
-        address to;
-        uint256 value;
-        bytes data;
-        uint256 gasLimit;
-        uint256 maxFeePerGas;
-        uint256 maxPriorityFeePerGas;
-        uint256 nonce;
-        uint256 deadline;
-        uint8 vType;
-    }
 
     struct Multicall {
         address to;
@@ -223,24 +195,9 @@ contract RoundtripDispatcher {
     }
 
     // -------------------------------------------------------------------------
-    // Inbound, path A — UEA-style entry (matches `UEA_EVM.executeUniversalTx`).
-    //   For Push-native contracts this is NEVER invoked by TSS.
-    // -------------------------------------------------------------------------
-
-    function executeUniversalTx(
-        UniversalPayload calldata payload,
-        bytes calldata /* signature */
-    ) external {
-        if (msg.sender != universalExecutorModule) revert NotUniversalExecutor();
-        ueaStyleCallbacks += 1;
-        lastUeaPayloadNonce = payload.nonce;
-        emit UeaStyleCallback(ueaStyleCallbacks, payload.nonce, payload.vType, payload.data);
-    }
-
-    // -------------------------------------------------------------------------
-    // Inbound, path B — docs-style 6-arg entry. Matches the example in
+    // Inbound — docs-style 6-arg `executeUniversalTx` matches the example in
     //   the public docs at push.org/docs/chain/build/contract-initiated-multichain-execution.
-    //   This IS the one TSS calls for Push-native contracts.
+    //   This IS the path TSS calls for Push-native contracts.
     // -------------------------------------------------------------------------
 
     function executeUniversalTx(
@@ -252,12 +209,12 @@ contract RoundtripDispatcher {
         bytes32 txId
     ) external payable {
         if (msg.sender != universalExecutorModule) revert NotUniversalExecutor();
-        if (seenDocsTxIds[txId]) revert TxAlreadyExecuted();
-        seenDocsTxIds[txId] = true;
-        docsStyleCallbacks += 1;
-        lastDocsTxId = txId;
-        emit DocsStyleCallback(
-            docsStyleCallbacks, txId, sourceChainNamespace, ceaAddress, prc20, amount
+        if (seenTxIds[txId]) revert TxAlreadyExecuted();
+        seenTxIds[txId] = true;
+        callbacks += 1;
+        lastTxId = txId;
+        emit Callback(
+            callbacks, txId, sourceChainNamespace, ceaAddress, prc20, amount
         );
     }
 


### PR DESCRIPTION
…xecuteUniversalTx path and update docs with verified TSS behavior

Remove dual-overload probe (UEA-style vs docs-style executeUniversalTx) now that empirical testing confirmed TSS dispatches only the 6-arg docs-style signature for Push-native contracts. Rename `docsStyleCallbacks` to `callbacks`, consolidate state variables, update README with verified round-trip flow and wire format details, and clarify that 2-arg executeUniversalTx is reserved