### PR TITLE
refactor: update deprecated API references to clarify convertOriginTo…

### DIFF
--- a/core-sdk-functions/contract-initiated-inbound-execution/index.ts
+++ b/core-sdk-functions/contract-initiated-inbound-execution/index.ts
@@ -90,7 +90,7 @@ async function main() {
   const dispatcher = new ethers.Contract(dispatcherAddress, DISPATCHER_ABI, sepoliaWallet);
 
   // 3) Show the dispatcher's UEA on Push — this is what the counter will see.
-  // We initialize a Push Chain client just to use `convertOriginToExecutor`.
+  // We initialize a Push Chain client just to use `deriveExecutorAccount`.
   const universalSigner = await PushChain.utils.signer.toUniversal(pushWallet);
   const pushChainClient = await PushChain.initialize(universalSigner, {
     network: PushChain.CONSTANTS.PUSH_NETWORK.TESTNET,

--- a/core-sdk-functions/utility-functions/README.md
+++ b/core-sdk-functions/utility-functions/README.md
@@ -60,7 +60,7 @@ Three library variants matching the docs:
 This file matches the **Utility Functions** docs page exactly, so it does NOT include:
 - `pushChainClient.universal.signMessage`, `prepareTransaction`, `executeTransactions`, `trackTransaction` — those belong in the [send-universal-transaction](../send-universal-transaction/) examples.
 - `pushChainClient.getAccountStatus()` — covered in [initialize-push-chain-client](../initialize-push-chain-client/).
-- The deprecated `convertOriginToExecutor` and `convertExecutorToOriginAccount` — replaced by `deriveExecutorAccount` and `resolveControllerAccount` respectively.
+- The legacy `convertOriginToExecutor` and `convertExecutorToOriginAccount` (removed in `@pushchain/core@6.0.0`), replaced by `deriveExecutorAccount` and `resolveControllerAccount` respectively.
 
 ## Network
 

--- a/tutorials/derive-universal-executor-account/README.md
+++ b/tutorials/derive-universal-executor-account/README.md
@@ -92,7 +92,7 @@ const account = PushChain.utils.account.toUniversal(
 );
 
 // Derive the Universal Executor Account (UEA).
-// Note: convertOriginToExecutor() is deprecated in favor of deriveExecutorAccount().
+// Note: convertOriginToExecutor() was removed in SDK v6 — use deriveExecutorAccount().
 const executorAddress = await PushChain.utils.account.deriveExecutorAccount(account);
 ```
 


### PR DESCRIPTION
…Executor removal in SDK v6

Update inline comments and documentation to reflect that convertOriginToExecutor/convertExecutorToOriginAccount were removed (not just deprecated) in @pushchain/core@6.0.0. Change "deprecated" to "removed" or "legacy" where appropriate and update deriveExecutorAccount usage comment in contract-initiated-inbound-execution example.