### PR TITLE
refactor: update Sepolia USDT contract address from 0x7169...BA06 to …

### DIFF
--- a/core-sdk-functions/pusd-mint-from-external-chain/.env.sample
+++ b/core-sdk-functions/pusd-mint-from-external-chain/.env.sample
@@ -8,7 +8,7 @@
 # Sepolia EOA private key. Used as the origin-chain signer. Fund this
 # address on Sepolia with:
 #   • Sepolia ETH for gas — https://cloud.google.com/application/web3/faucet/ethereum/sepolia
-#   • At least 1 USDT — mint via https://sepolia.etherscan.io/address/0x7169D38820dfd117C3FA1f22a697dBA58d90BA06#writeContract
+#   • At least 1 USDT — mint via https://sepolia.etherscan.io/address/0xC4230aEaFcF6b8B49a7b4e53886420f00ff71876#writeContract
 #     (call `mint` with `1000000` for 1 USDT — 6 decimals).
 #
 # Reuse this same key when running ../pusd-redeem Scenario 2 (cross-chain

--- a/core-sdk-functions/pusd-mint-from-external-chain/README.md
+++ b/core-sdk-functions/pusd-mint-from-external-chain/README.md
@@ -106,7 +106,7 @@ When the user holds the reserve token on the origin chain (USDT on Sepolia, here
 ## 🔧 Setup Requirements
 
 - **Sepolia ETH** for the origin transaction's gas. Faucet: <https://cloud.google.com/application/web3/faucet/ethereum/sepolia>.
-- **USDT on Sepolia** at address `0x7169D38820dfd117C3FA1f22a697dBA58d90BA06` — this is the real test ERC-20 on Sepolia. Mint via the contract's `mint` function on [Sepolia Etherscan](https://sepolia.etherscan.io/address/0x7169D38820dfd117C3FA1f22a697dBA58d90BA06#writeContract).
+- **USDT on Sepolia** at address `0xC4230aEaFcF6b8B49a7b4e53886420f00ff71876` — this is the real test ERC-20 on Sepolia. Mint via the contract's `mint` function on [Sepolia Etherscan](https://sepolia.etherscan.io/address/0xC4230aEaFcF6b8B49a7b4e53886420f00ff71876#writeContract).
   > ⚠️ Don't confuse this with `0xCA0C5E6F002A389E1580F0DB7cd06e4549B5F9d3` — that is the **Donut representation** of Sepolia USDT (where the relay bridges to and where the multicall approves + deposits). The Donut address only exists on Push Chain, not on Sepolia.
 - Node.js v18+.
 

--- a/core-sdk-functions/pusd-mint-from-external-chain/index.ts
+++ b/core-sdk-functions/pusd-mint-from-external-chain/index.ts
@@ -45,7 +45,7 @@ const USDT_DONUT = '0xCA0C5E6F002A389E1580F0DB7cd06e4549B5F9d3' as `0x${string}`
 // the relay bridges it to Donut). Mint test USDT from the contract's `mint`
 // function on Sepolia Etherscan. Source: @pushchain/core token registry —
 // `pushChainClient.moveable.token.USDT` resolves to this on a Sepolia origin.
-const USDT_SEPOLIA = '0x7169D38820dfd117C3FA1f22a697dBA58d90BA06' as `0x${string}`;
+const USDT_SEPOLIA = '0xC4230aEaFcF6b8B49a7b4e53886420f00ff71876' as `0x${string}`;
 
 // Sentinel for multicall mode on the universal transaction layer.
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as `0x${string}`;

--- a/core-sdk-functions/pusd-redeem/index.ts
+++ b/core-sdk-functions/pusd-redeem/index.ts
@@ -51,12 +51,12 @@ const PUSD_MANAGER = '0x7A24Eea43a1095e9Dc652AB9Cba156a93Ed5Ed46';
 
 // USDT.eth — Donut representation of Sepolia USDT. Hop 1 returns this on
 // Donut; hop 2 bridges it back to Sepolia USDT
-// (`0x7169D38820dfd117C3FA1f22a697dBA58d90BA06`) via `funds`.
+// (`0xC4230aEaFcF6b8B49a7b4e53886420f00ff71876`) via `funds`.
 const USDT_DONUT = '0xCA0C5E6F002A389E1580F0DB7cd06e4549B5F9d3';
 
 // USDT on Ethereum Sepolia — only used for reading the destination balance
 // before/after to demonstrate the cross-chain delivery.
-const USDT_SEPOLIA = '0x7169D38820dfd117C3FA1f22a697dBA58d90BA06';
+const USDT_SEPOLIA = '0xC4230aEaFcF6b8B49a7b4e53886420f00ff71876';
 
 // Default amount to redeem in both scenarios (6 decimals → 1 PUSD).
 const PUSD_AMOUNT_HUMAN = '1';

--- a/core-sdk-functions/send-universal-transaction-pay-gas-with-any-token/README.md
+++ b/core-sdk-functions/send-universal-transaction-pay-gas-with-any-token/README.md
@@ -139,7 +139,7 @@ You'll need on **Ethereum Sepolia**:
 
 **USDT on Sepolia** (real ERC-20 on Sepolia — call `mint`):
 ```
-https://sepolia.etherscan.io/address/0x7169D38820dfd117C3FA1f22a697dBA58d90BA06#writeContract
+https://sepolia.etherscan.io/address/0xC4230aEaFcF6b8B49a7b4e53886420f00ff71876#writeContract
 ```
 
 **USDC on Sepolia** (real ERC-20 on Sepolia — call `mint`):

--- a/core-sdk-functions/send-universal-transaction-with-funds/README.md
+++ b/core-sdk-functions/send-universal-transaction-with-funds/README.md
@@ -132,7 +132,7 @@ You'll need:
 
 Mint test USDT on **Ethereum Sepolia** (the real ERC-20 the user holds before bridging):
 ```
-https://sepolia.etherscan.io/address/0x7169D38820dfd117C3FA1f22a697dBA58d90BA06#writeContract
+https://sepolia.etherscan.io/address/0xC4230aEaFcF6b8B49a7b4e53886420f00ff71876#writeContract
 ```
 
 Call the `mint` function to get test USDT.

--- a/core-sdk-functions/send-universal-transaction/index.ts
+++ b/core-sdk-functions/send-universal-transaction/index.ts
@@ -1,4 +1,15 @@
 // Full Documentation: https://push.org/docs/chain/build/send-universal-transaction
+//
+// PROGRESS HOOK:
+// The progressHook callback allows you to monitor transaction progress through different stages:
+// - 'preparing': Transaction is being prepared
+// - 'signing': Transaction is being signed
+// - 'sending': Transaction is being sent to the network
+// - 'waiting': Waiting for transaction confirmation
+// - 'confirmed': Transaction has been confirmed
+// - 'error': An error occurred during processing
+//
+// Usage: progressHook: (step: string, data?: any) => void
 
 // Import Push Chain Core
 import { PushChain } from '@pushchain/core';
@@ -62,9 +73,12 @@ async function quickstartExample() {
   try {
     // Note: This would fail in playground without funds
     // In production, ensure wallet has funds
-    const txResponse = await pushChainClient.universal.sendTransaction({
+    const txResponse = await (pushChainClient.universal.sendTransaction as any)({
       to: '0x0000000000000000000000000000000000042101',
       value: BigInt('100000000000000000'), // 0.1 PC in wei
+      progressHook: (step: string, data?: any) => {
+        console.log(`📊 Progress: ${step}`, data ? `| Data: ${JSON.stringify(data)}` : '');
+      },
     });
     console.log('Transaction Response:', JSON.stringify(txResponse));
   } catch (error) {
@@ -115,9 +129,12 @@ async function ethersV6() {
   console.log('\n4. Send Universal Transaction');
   try {
     // Example: Send 0.001 ETH to a random address
-    const txResponse = await pushChainClient.universal.sendTransaction({
+    const txResponse = await (pushChainClient.universal.sendTransaction as any)({
       to: '0x0000000000000000000000000000000000042101', // receiver address
       value: PushChain.utils.helpers.parseUnits('0.001', 18), // 0.001 PC in uPC (wei)
+      progressHook: (step: string, data?: any) => {
+        console.log(`📊 Progress: ${step}`, data ? `| Data: ${JSON.stringify(data)}` : '');
+      },
     });
     console.log('📤 Transaction Response:', txResponse);
 
@@ -183,9 +200,12 @@ async function viemExample() {
 
   console.log('\n4. Send Universal Transaction');
   try {
-    const txResponse = await pushChainClient.universal.sendTransaction({
+    const txResponse = await (pushChainClient.universal.sendTransaction as any)({
       to: '0x0000000000000000000000000000000000042101',
       value: BigInt(1000000000000000), // 0.001 PC in wei
+      progressHook: (step: string, data?: any) => {
+        console.log(`📊 Progress: ${step}`, data ? `| Data: ${JSON.stringify(data)}` : '');
+      },
     });
     console.log('📤 Transaction Response:', txResponse);
 
@@ -251,9 +271,12 @@ async function solanaExample() {
 
   console.log('\n4. Send Universal Transaction');
   try {
-    const txResponse = await pushChainClient.universal.sendTransaction({
+    const txResponse = await (pushChainClient.universal.sendTransaction as any)({
       to: '0x0000000000000000000000000000000000042101',
       value: BigInt(1000000000000), // .001 PC
+      progressHook: (step: string, data?: any) => {
+        console.log(`📊 Progress: ${step}`, data ? `| Data: ${JSON.stringify(data)}` : '');
+      },
     });
     console.log('📤 Transaction Response:', txResponse);
 


### PR DESCRIPTION
…0xC423...1876 across all examples and add progressHook monitoring to send-universal-transaction

Update USDT_SEPOLIA constant and documentation references to new test token contract address (0xC4230aEaFcF6b8B49a7b4e53886420f00ff71876) in pusd-mint-from-external-chain, pusd-redeem, and send-universal-transaction-with-funds examples. Add progressHook callback with inline documentation and usage examples to all sendTransaction calls in